### PR TITLE
Modify parse_cookies to split on first occurrence of '=' only

### DIFF
--- a/R/request.R
+++ b/R/request.R
@@ -437,7 +437,7 @@ Request <- R6Class('Request',
     parse_cookies = function() {
       if (is.null(self$headers$Cookie)) return(list())
       cookies <- trimws(strsplit(self$headers$Cookie, ';')[[1]])
-      cookies <- unlist(strsplit(cookies, '='))
+      cookies <- unlist(strsplit(sub("=", ";", cookies), ";"))
       structure(
         as.list(url_decode(cookies[c(FALSE, TRUE)])),
         names = cookies[c(TRUE, FALSE)]


### PR DESCRIPTION
The `parse_cookies` function in `request.R` attempts to split cookies on each occurrence of `=`; this appears to generate errors such as the following when multiple instances of `=` occur within a cookie:

```
ERROR: 'names' attribute [11] must be the same length as the vector [10]
```

This may be reproduced by using `curl` or a similar tool to pass a cookie string containing two or more `=`, e.g.

```
curl -v -H "Cookie: a=1=2" 127.0.0.1:8050
```

The original lines are here:

https://github.com/thomasp85/reqres/blob/c69c05309d4cc76a95cc6b103a6d9f9e2dc251b4/R/request.R#L437-L445

This pull request proposes to modify line 440:

```
cookies <- unlist(strsplit(sub("=", ";", cookies), ";"))
```

Since `sub` will only replace the first matching `=`, `strsplit` will split the line only once.